### PR TITLE
Replace UTF-8 dashes and apostrophe with ASCII.

### DIFF
--- a/sass/_config.scss
+++ b/sass/_config.scss
@@ -12,7 +12,7 @@ $_BROWSER-DEFAULT-FONT-SIZE: 16px;
 // Default Ratios
 // --------------
 /// Common pre-defined ratios that you can access by name.
-/// Numeric ratios (like the musical scale) are exponential —
+/// Numeric ratios (like the musical scale) are exponential -
 /// while a 'linear' scale uses simple multipliers.
 /// This variable should not be edited.
 /// Use the `$ratios` variable to add your own ratios,

--- a/sass/_units.scss
+++ b/sass/_units.scss
@@ -58,7 +58,7 @@
 ///   Some units (`ch`, `vw`, `vh`, `vmin`, `vmax`) cannot be converted.
 /// @param {Number} $from-context [$_BROWSER-DEFAULT-FONT-SIZE] -
 ///   When converting from relative units,
-///   the absolute length (in px) to which $length refers —
+///   the absolute length (in px) to which $length refers -
 ///   e.g. for `$lengths` in em units, would normally be the
 ///   font-size of the current element.
 /// @param {Number} $to-context [$from-context] -
@@ -82,7 +82,7 @@
   // Warn and escape when units are not convertable
   @each $units in ($from-unit, $to-unit) {
     @if not index($_convertable, $units) {
-      @warn '#{$units} units can’t be reliably converted; Returning original value.';
+      @warn "#{$units} units can't be reliably converted; Returning original value.";
       @return $length;
     }
   }


### PR DESCRIPTION
This avoids errors like the following in a non-UTF-8 environment:

```
error site/css/screen.scss (Line 15 of node_modules/accoutrement-scale/sass/_config.scss: Invalid US-ASCII character "\xE2")
```
