### PR TITLE
3.0

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -62,7 +62,7 @@ rules:
     - max-depth: 3
   placeholder-name-format: 2
   property-sort-order: 2
-  quotes: 2
+  quotes: 1
   shorthand-values: 2
   url-quotes: 2
   variable-for-property: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,4 @@ Accoutrement-Scale Changelog
   e.g. `'my-size': 24px ('add': 12px)`,
   where `add` is an available function
   that will accept `24px, 12px` as arguments.
-- Support first-class functions in Sass 3.5 (I hope).
+- Support first-class functions in Sass 3.5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+Accoutrement-Scale Changelog
+============================
+
+
+3.0.0 - 02/29/17
+----------------
+- BREAKING: Don't convert units unless specifically requested.
+  This allows you to define preferred units per-item
+  in the configuration map.
+- BREAKING: Remove `$default-units` setting. See above.
+- Allow arbitrary adjustment functions
+  in the `$sizes` map,
+  e.g. `'my-size': 24px ('add': 12px)`,
+  where `add` is an available function
+  that will accept `24px, 12px` as arguments.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Accoutrement-Scale Changelog
 ============================
 
 
-3.0.0 - 02/29/17
+3.0.0 - 03/08/17
 ----------------
 - BREAKING: Don't convert units unless specifically requested.
   This allows you to define preferred units per-item

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,4 @@ Accoutrement-Scale Changelog
   e.g. `'my-size': 24px ('add': 12px)`,
   where `add` is an available function
   that will accept `24px, 12px` as arguments.
-
+- Support first-class functions in Sass 3.5 (I hope).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 accoutrement-scale
 ==================
 
-Sass typography [Accoutrement][accoutrement]
-by [OddBird][oddbird].
-Sass size & scale management tools.
-Generate sizes based on [modular scales][ms],
-gather all your sizes into a single map,
-and access them by name in various ways.
+Sass size & scale management tools
+by [OddBird][oddbird],
+part of our [Accoutrement][accoutrement] suite.
+Gather all your sizes into a single map,
+generate new sizes based on [modular scales][ms]
+or arbitrary functions,
+and access them by name.
 
 [accoutrement]: http://oddbird.net/accoutrement/
 [oddbird]: http://oddbird.net/

--- a/README.md
+++ b/README.md
@@ -26,19 +26,16 @@ Import the library:
 @import 'path/to/accoutrement-scale/sass/scale'
 ```
 
-Establish your palette of ratios and sizes,
-along with the default units needed for output:
+Establish your palette of ratios and sizes:
 
 ```scss
-$default-units: 'rem';
-
 $ratios: (
   'my-ratio': 1.25,
 );
 
 $sizes: (
   'root': 24px,
-  'rhythm': 'root' ('fifth': 1),
+  'rhythm': 'root' ('fifth': 1, 'convert-units': 'rem'),
 
   'h1': 'root' ('my-ratio': 3),
   'h2': 'root' ('my-ratio': 2),
@@ -46,6 +43,17 @@ $sizes: (
 
   'page': '8in',
 );
+```
+
+Results will be returned in the units they were defined,
+but can be converted in the map settings (as above),
+or on-the-fly using `size`:
+
+```scss
+.example {
+  // size('page') would return `8in`...
+  width: size('page', 'px');
+}
 ```
 
 Access your sizes from anywhere,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "accoutrement-scale",
-  "version": "2.0.0",
+  "version": "3.0.0-alpha.1",
   "description": "Size and scale helpers for typography and layout.",
   "homepage": "https://github.com/oddbird/accoutrement-scale",
   "repository": {
@@ -15,8 +15,8 @@
     "mathsass": "^0.9.5",
     "mocha": "^2.4.5",
     "sass-true": "^2.2.1",
-    "sassdoc": "^2.1.20",
-    "sassdoc-theme-herman": "^0.2.1"
+    "sassdoc": "^2.2.0",
+    "sassdoc-theme-herman": "^0.5.5"
   },
   "author": "Miriam Suzanne <miriam@oddbird.net>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "accoutrement-scale",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0",
   "description": "Size and scale helpers for typography and layout.",
   "homepage": "https://github.com/oddbird/accoutrement-scale",
   "repository": {

--- a/sass/_config.scss
+++ b/sass/_config.scss
@@ -80,15 +80,6 @@ $ratios: () !default;
 }
 
 
-// Default Units
-// -------------
-/// Defined the default units to use when accessing sizes.
-///
-/// @group config
-/// @type String
-$default-units: 'rem' !default;
-
-
 // Sizes
 // -----
 /// Defined a palette of common sizes to be used across your project,
@@ -104,7 +95,7 @@ $default-units: 'rem' !default;
 ///   used for calculating relative sizes.
 $sizes: (
   'root': $_BROWSER-DEFAULT-FONT-SIZE,
-  'text': 'root',
+  'text': 'root' ('convert-units': 'rem'),
   'rhythm': 'text' ('fifth': 1),
 
   'h1': 'text' ('linear': 4),

--- a/sass/_scale.scss
+++ b/sass/_scale.scss
@@ -1,6 +1,7 @@
 // Scales
 // ======
 
+@import 'utility';
 @import 'config';
 @import 'math';
 @import 'units';

--- a/sass/_size.scss
+++ b/sass/_size.scss
@@ -37,7 +37,7 @@
 
   // Adjustments
   @each $key, $value in $adjust {
-    $size: _accoutrement-adjust-size($size, $key, $value);
+    $size: _ac-scale-adjust-size($size, $key, $value);
   }
 
   // Validation
@@ -134,7 +134,7 @@
 ///   or additional arguments to be passed to a function.
 /// @return {Number} -
 ///   Results of the adjustment.
-@function _accoutrement-adjust-size(
+@function _ac-scale-adjust-size(
   $size,
   $key,
   $value
@@ -147,7 +147,8 @@
     $multiplier: _accoutrement-pow($ratio, $value);
     @return $size * $multiplier;
   } @else if function-exists($key) {
-    @return call($key, $size, $value...);
+    $function: _ac-scale-get-function($key);
+    @return call($function, $size, $value...);
   }
 
   @error '#{$key} is not a valid ratio or function for adusting sizes.';

--- a/sass/_size.scss
+++ b/sass/_size.scss
@@ -17,7 +17,7 @@
 ///   For the sake of consistent documentation,
 ///   I recommend keeping adjustments in the configuration
 ///   whenever possible.
-/// @param {String} $unit [$default-units] -
+/// @param {String} $unit [null] -
 ///   The desired units for the output (e.g. `px` or `rem`).
 /// @throw -
 ///   The calculated value is not a valid CSS length.
@@ -25,7 +25,7 @@
 ///   The calculated length, in the requested units.
 @function size(
   $size,
-  $unit: $default-units
+  $unit: null
 ) {
   // Parse arguments
   $size: map-get($sizes, $size) or $size;
@@ -36,14 +36,8 @@
   $size: if(map-has-key($sizes, $base), size($base, false), $base);
 
   // Adjustments
-  @each $ratio, $value in $adjust {
-    $ratio: _get-ratio($ratio);
-    @if $ratio == 'linear' {
-      $size: $size * $value;
-    } @else {
-      $multiplier: _accoutrement-pow($ratio, $value);
-      $size: round($size * $multiplier);
-    }
+  @each $key, $value in $adjust {
+    $size: _accoutrement-adjust-size($size, $key, $value);
   }
 
   // Validation
@@ -76,13 +70,13 @@
 ///   For the sake of consistent documentation,
 ///   I recommend keeping adjustments in the configuration
 ///   whenever possible.
-/// @param {String} $unit [$default-units] -
+/// @param {String} $unit [null] -
 ///   The desired units for the output (e.g. `px` or `rem`).
 /// @return {Length} -
 ///   The calculated negative length, in the requested units.
 @function negative(
   $size,
-  $unit: $default-units
+  $unit: null
 ) {
   @return 0 - size($size, $unit);
 }
@@ -103,17 +97,60 @@
 ///   For the sake of consistent documentation,
 ///   I recommend keeping adjustments in the configuration
 ///   whenever possible.
-/// @param {String} $unit [$default-units] -
+/// @param {String} $unit [null] -
 ///   The desired units for the output (e.g. `px` or `rem`).
 /// @output -
 ///   Equal CSS height and width properties,
 ///   set to the given size and units.
 @mixin square(
   $size,
-  $unit: $default-units
+  $unit: null
 ) {
   $size: size($size, $unit);
 
   height: $size;
   width: $size;
 }
+
+
+
+// Adjust Size
+// ===========
+/// Calculate ratio, linear, or arbitrary adjustments
+/// to a base size.
+///
+/// @access private
+///
+/// @param {Number} $size -
+///   The original size to perform adjusments on
+/// @param {String | Number} $key -
+///   The adjustment to perform,
+///   given as either a numeric ratio,
+///   named ratio keyword,
+///   or function name to call.
+/// @param {Any} $value -
+///   Any required adjustment arguments,
+///   such as the number of times to apply a ratio,
+///   or additional arguments to be passed to a function.
+/// @return {Number} -
+///   Results of the adjustment.
+@function _accoutrement-adjust-size(
+  $size,
+  $key,
+  $value
+) {
+  $ratio: _get-ratio($key);
+
+  @if $ratio == 'linear' {
+    @return $size * $value;
+  } @else if (type-of($ratio) == 'number') {
+    $multiplier: _accoutrement-pow($ratio, $value);
+    @return $size * $multiplier;
+  } @else if function-exists($key) {
+    @return call($key, $size, $value...);
+  }
+
+  @error '#{$key} is not a valid ratio or function for adusting sizes.';
+}
+
+

--- a/sass/_size.scss
+++ b/sass/_size.scss
@@ -46,7 +46,7 @@
   }
 
   // Units
-  @if $unit and not index('ch' 'vw' 'vh' 'vmin', unit($size)) {
+  @if $unit {
     $size: convert-units($size, $unit);
   }
 

--- a/sass/_size.scss
+++ b/sass/_size.scss
@@ -146,7 +146,7 @@
   } @else if (type-of($ratio) == 'number') {
     $multiplier: _accoutrement-pow($ratio, $value);
     @return $size * $multiplier;
-  } @else if function-exists($key) {
+  } @else if (type-of($key) == 'function') or function-exists($key) {
     $function: _ac-scale-get-function($key);
     @return call($function, $size, $value...);
   }

--- a/sass/_type.scss
+++ b/sass/_type.scss
@@ -19,8 +19,13 @@
   $size: 'root',
   $rhythm: 'rhythm'
 ) {
-  $font-size: size($size, 'px');
-  $line-height: size($rhythm, 'px');
+  $font-size: size($size);
+  $line-height: size($rhythm);
+
+  @if (not comparable($font-size, $line-height)) {
+    $font-size: convert-units($font-size, 'px');
+    $line-height: convert-units($line-height, 'px');
+  }
 
   @return ceil(2 * $font-size / $line-height) / 2;
 }

--- a/sass/_units.scss
+++ b/sass/_units.scss
@@ -82,7 +82,7 @@
   // Warn and escape when units are not convertable
   @each $units in ($from-unit, $to-unit) {
     @if not index($_convertable, $units) {
-      @warn '#{$units} units can’t be reliably converted; Returning original value.';
+      @warn "#{$units} units can't be reliably converted; Returning original value.";
       @return $length;
     }
   }

--- a/sass/_units.scss
+++ b/sass/_units.scss
@@ -53,7 +53,7 @@
 ///
 /// @param {Number} $length -
 ///   The length to be converted
-/// @param {String} $to-unit [$default-units] -
+/// @param {String} $to-unit -
 ///   The desired units to convert to.
 ///   Some units (`ch`, `vw`, `vh`, `vmin`, `vmax`) cannot be converted.
 /// @param {Number} $from-context [$_BROWSER-DEFAULT-FONT-SIZE] -
@@ -67,7 +67,7 @@
 ///   Defaults to the same as `$from-context`, since it is rarely needed.
 @function convert-units(
   $length,
-  $to-unit: $default-units,
+  $to-unit,
   $from-context: $_BROWSER-DEFAULT-FONT-SIZE,
   $to-context: $from-context
 ) {
@@ -82,7 +82,7 @@
   // Warn and escape when units are not convertable
   @each $units in ($from-unit, $to-unit) {
     @if not index($_convertable, $units) {
-      @warn "#{$units} units can't be reliably converted; Returning original value.";
+      @warn '#{$units} units can’t be reliably converted; Returning original value.';
       @return $length;
     }
   }

--- a/sass/_units.scss
+++ b/sass/_units.scss
@@ -82,7 +82,7 @@
   // Warn and escape when units are not convertable
   @each $units in ($from-unit, $to-unit) {
     @if not index($_convertable, $units) {
-      @warn "#{$units} units can't be reliably converted; Returning original value.";
+      @warn "`#{$units}` units can't be reliably converted; Returning original value.";
       @return $length;
     }
   }

--- a/sass/_utility.scss
+++ b/sass/_utility.scss
@@ -1,0 +1,33 @@
+// Utilities
+// =========
+
+
+
+// Get Function
+// ------------
+/// Get a first-class function in Sass 3.5+,
+/// or the function name string (unchanged)
+/// in older Sass versions.
+///
+/// @access private
+///
+/// @param {String} $function -
+///   The name (string) of a function to be called.
+/// @return {String | Function} -
+///   Returns a first-class function in Sass 3.5+,
+///   or the function name string in older Sass versions.
+@function _ac-scale-get-function(
+  $function
+) {
+  $type: type-of($function);
+
+  @if ($type != 'string') {
+    @error 'Invalid function-name, [#{$type}] `#{$function}` must be a string';
+  }
+
+  @if function-exists('get-function') {
+    @return get-function($function);
+  }
+
+  @return $function;
+}

--- a/sass/_utility.scss
+++ b/sass/_utility.scss
@@ -8,11 +8,15 @@
 /// Get a first-class function in Sass 3.5+,
 /// or the function name string (unchanged)
 /// in older Sass versions.
+/// This is safe to use internally,
+/// as it allows users to pass in
+/// either a string, or a previously-captured function.
 ///
 /// @access private
 ///
-/// @param {String} $function -
-///   The name (string) of a function to be called.
+/// @param {String | Function} $function -
+///   The name (string) of a function,
+///   or the function to be called.
 /// @return {String | Function} -
 ///   Returns a first-class function in Sass 3.5+,
 ///   or the function name string in older Sass versions.
@@ -21,13 +25,15 @@
 ) {
   $type: type-of($function);
 
-  @if ($type != 'string') {
-    @error 'Invalid function-name, [#{$type}] `#{$function}` must be a string';
+  @if ($type == 'function') {
+    @return $function;
+  } @else if ($type == 'string') {
+    @if function-exists('get-function') {
+      @return get-function($function);
+    }
+
+    @return $function;
   }
 
-  @if function-exists('get-function') {
-    @return get-function($function);
-  }
-
-  @return $function;
+  @error 'Invalid function-name, [#{$type}] `#{$function}` must be a function or string';
 }

--- a/test/scss/_size.scss
+++ b/test/scss/_size.scss
@@ -15,9 +15,16 @@ $sizes: map-merge($sizes, $test-sizes);
 @include test-module('size [function]') {
   @include test('Get size from map setting') {
     @include assert-equal(
-      size('rhythm'),
-      1.5rem,
+      size('root'),
+      16px,
       'Returns named size from $sizes map.');
+  }
+
+  @include test('Get size from unit adjustment') {
+    @include assert-equal(
+      size('text'),
+      1rem,
+      'Returns size calculated from unit adjustment.');
   }
 
   @include test('Get size from linear adjustment') {
@@ -30,7 +37,7 @@ $sizes: map-merge($sizes, $test-sizes);
   @include test('Get size from ratio adjustment') {
     @include assert-equal(
       size('big'),
-      7.625rem,
+      7.59375rem,
       'Returns size calculated from ratio adjustment.');
   }
 
@@ -83,5 +90,49 @@ $sizes: map-merge($sizes, $test-sizes);
         width: 4rem;
       }
     }
+  }
+}
+
+
+// For testing...
+@function _plus-test-function(
+  $size,
+  $add
+) {
+  @return $size + $add;
+}
+
+
+// Adjust Size [function]
+// ----------------------
+@include test-module('adjust-size [function]') {
+  @include test('Adjust units') {
+    @include assert-equal(
+      _accoutrement-adjust-size(24px, 'convert-units', 'rem'),
+      1.5rem);
+  }
+
+  @include test('Linear adjustment') {
+    @include assert-equal(
+      _accoutrement-adjust-size(24px, 'linear', 3),
+      72px);
+  }
+
+  @include test('Explicit ratio adjustment') {
+    @include assert-equal(
+      _accoutrement-adjust-size(24px, 1.5, 2),
+      54px);
+  }
+
+  @include test('Named ratio adjustment') {
+    @include assert-equal(
+      _accoutrement-adjust-size(24px, 'fifth', 2),
+      54px);
+  }
+
+  @include test('Arbitrary adjustment') {
+    @include assert-equal(
+      _accoutrement-adjust-size(24px, '_plus-test-function', 2px),
+      24px + 2px);
   }
 }

--- a/test/scss/_size.scss
+++ b/test/scss/_size.scss
@@ -105,34 +105,34 @@ $sizes: map-merge($sizes, $test-sizes);
 
 // Adjust Size [function]
 // ----------------------
-@include test-module('adjust-size [function]') {
+@include test-module('_ac-scale-adjust-size [function]') {
   @include test('Adjust units') {
     @include assert-equal(
-      _accoutrement-adjust-size(24px, 'convert-units', 'rem'),
+      _ac-scale-adjust-size(24px, 'convert-units', 'rem'),
       1.5rem);
   }
 
   @include test('Linear adjustment') {
     @include assert-equal(
-      _accoutrement-adjust-size(24px, 'linear', 3),
+      _ac-scale-adjust-size(24px, 'linear', 3),
       72px);
   }
 
   @include test('Explicit ratio adjustment') {
     @include assert-equal(
-      _accoutrement-adjust-size(24px, 1.5, 2),
+      _ac-scale-adjust-size(24px, 1.5, 2),
       54px);
   }
 
   @include test('Named ratio adjustment') {
     @include assert-equal(
-      _accoutrement-adjust-size(24px, 'fifth', 2),
+      _ac-scale-adjust-size(24px, 'fifth', 2),
       54px);
   }
 
   @include test('Arbitrary adjustment') {
     @include assert-equal(
-      _accoutrement-adjust-size(24px, '_plus-test-function', 2px),
+      _ac-scale-adjust-size(24px, '_plus-test-function', 2px),
       24px + 2px);
   }
 }

--- a/test/scss/_size.scss
+++ b/test/scss/_size.scss
@@ -5,6 +5,7 @@
 $test-sizes: (
   'big': 'text' ('fifth': 5),
   'small': 'text' ('octave': -1),
+  'viewport': 10vw,
 );
 
 $sizes: map-merge($sizes, $test-sizes);
@@ -60,6 +61,12 @@ $sizes: map-merge($sizes, $test-sizes);
     $expect: 24vmin;
     @include assert-equal($test, $expect,
       'Returns vmin size as given.');
+  }
+
+  @include test('Allow viewport units without warning') {
+    @include assert-equal(
+      size('viewport'),
+      10vw);
   }
 }
 

--- a/test/scss/_size.scss
+++ b/test/scss/_size.scss
@@ -6,6 +6,7 @@ $test-sizes: (
   'big': 'text' ('fifth': 5),
   'small': 'text' ('octave': -1),
   'viewport': 10vw,
+  'percent': 20%,
 );
 
 $sizes: map-merge($sizes, $test-sizes);
@@ -67,6 +68,12 @@ $sizes: map-merge($sizes, $test-sizes);
     @include assert-equal(
       size('viewport'),
       10vw);
+  }
+
+  @include test('Allow viewport units without warning') {
+    @include assert-equal(
+      size('percent'),
+      20%);
   }
 }
 

--- a/test/scss/_type.scss
+++ b/test/scss/_type.scss
@@ -44,7 +44,7 @@
       }
 
       @include expect {
-        font-size: 1.5rem;
+        font-size: 24px;
         line-height: 4.5rem;
       }
     }

--- a/test/scss/_utility.scss
+++ b/test/scss/_utility.scss
@@ -1,0 +1,22 @@
+// Sass Utilities
+// ==============
+
+
+@include test-module('Get Function [function]') {
+  $test: _ac-scale-get-function('size');
+  $expect: 'size';
+
+  @if function-exists('get-function') {
+    $expect: get-function('size');
+  }
+
+  @include test('Returns a function or function-name') {
+    @include assert-equal($test, $expect);
+  }
+
+  @include test('Returned function or name is callable') {
+    @include assert-equal(
+      call($test, 'root'),
+      size('root'));
+  }
+}

--- a/test/scss/_utility.scss
+++ b/test/scss/_utility.scss
@@ -8,6 +8,12 @@
 
   @if function-exists('get-function') {
     $expect: get-function('size');
+
+    @include test('Functions are returned without change') {
+      @include assert-equal(
+        _ac-scale-get-function($expect),
+        $expect);
+    }
   }
 
   @include test('Returns a function or function-name') {

--- a/test/scss/test.scss
+++ b/test/scss/test.scss
@@ -4,6 +4,7 @@
 @import '../../node_modules/sass-true/sass/true';
 @import '../../sass/scale';
 
+@import 'utility';
 @import 'config';
 @import 'math';
 @import 'units';


### PR DESCRIPTION
- BREAKING: Don't convert units unless specifically requested.
  This allows you to define preferred units per-item
  in the configuration map.
- BREAKING: Remove `$default-units` setting. See above.
- Allow arbitrary adjustment functions
  in the `$sizes` map,
  e.g. `'my-size': 24px ('add': 12px)`,
  where `add` is an available function
  that will accept `24px, 12px` as arguments.
- Support first-class functions in Sass 3.5 (I hope).
